### PR TITLE
Implement support for class profiles

### DIFF
--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -59,6 +59,18 @@ lazy val test = project
     name := "test"
   )
 
+lazy val testDepsOne = project
+  .in(file("test-deps") / "one")
+  .settings(
+    name := "test-deps-one"
+  )
+
+lazy val testDepsTwo = project
+  .in(file("test-deps") / "two")
+  .settings(
+    name := "test-deps-two"
+  )
+
 lazy val root = project
   .in(file("."))
   .settings(
@@ -73,4 +85,4 @@ lazy val root = project
         .setPreference(DanglingCloseParenthesis, Preserve)
     ))
   )
- .aggregate(daemon, test)
+ .aggregate(daemon, test, testDepsOne, testDepsTwo)

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JavaArgs.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JavaArgs.scala
@@ -29,7 +29,7 @@ object JavaArgs {
           step(
             if (as.tail.isEmpty) Seq.empty else as.tail.tail,
             as.tail.headOption.fold(accum.copy(errors = accum.errors :+ s"$flag requires class path specification")) { cp =>
-              accum.copy(cp = cp.split(":").toVector)
+              accum.copy(cp = classPathStrings(cp))
             }
           )
 

--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/package.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/package.scala
@@ -1,0 +1,16 @@
+package com.github.huntc
+
+import com.github.huntc.landlord.JvmExecutor.resolvePaths
+import java.net.URL
+import java.nio.file.{ Path, Paths }
+import scala.collection.immutable.Seq
+
+package object landlord {
+  private[landlord] val ClassProfilesProperty = "landlord.class-profile"
+
+  private[landlord] def classPathStrings(cp: String): Seq[String] =
+    cp.split(":").toVector
+
+  private[landlord] def classPathUrls(base: Path, classPath: Seq[String]): Seq[URL] =
+    classPath.flatMap(cp => resolvePaths(base, Paths.get(cp)).map(_.toUri.toURL))
+}

--- a/landlordd/project/Dependencies.scala
+++ b/landlordd/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.Resolver.bintrayRepo
 
 object Versions {
   lazy val akka = "2.5.8"
-  lazy val alpakka = "0.18+6-1a29fcff"
+  lazy val alpakka = "0.18"
   lazy val commonsCompress = "1.15"
   lazy val logbackClassic = "1.2.3"
   lazy val scalaTest = "3.0.4"

--- a/landlordd/project/Dependencies.scala
+++ b/landlordd/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.Resolver.bintrayRepo
 
 object Versions {
   lazy val akka = "2.5.8"
-  lazy val alpakka = "0.18"
+  lazy val alpakka = "0.18+6-1a29fcff"
   lazy val commonsCompress = "1.15"
   lazy val logbackClassic = "1.2.3"
   lazy val scalaTest = "3.0.4"

--- a/landlordd/test-deps/one/src/main/java/dep/Greeting.java
+++ b/landlordd/test-deps/one/src/main/java/dep/Greeting.java
@@ -1,0 +1,5 @@
+package dep;
+
+public class Greeting {
+    public static String value = "one";
+}

--- a/landlordd/test-deps/two/src/main/java/dep/Greeting.java
+++ b/landlordd/test-deps/two/src/main/java/dep/Greeting.java
@@ -1,0 +1,5 @@
+package dep;
+
+public class Greeting {
+    public static String value = "two";
+}

--- a/landlordd/test/src/main/java/dep/Greeting.java
+++ b/landlordd/test/src/main/java/dep/Greeting.java
@@ -1,0 +1,5 @@
+package dep;
+
+public class Greeting {
+    public static String value = "built-in";
+}

--- a/landlordd/test/src/main/java/example/Profile.java
+++ b/landlordd/test/src/main/java/example/Profile.java
@@ -1,0 +1,20 @@
+package example;
+
+import dep.Greeting;
+
+/**
+ * A test program that prints the value of dep.Greeting.value
+ * which is loaded dynamically via landlord's class profile support
+ */
+public class Profile {
+    public static void main(String[] args) {
+        try {
+            System.out.println(Greeting.value);
+
+            System.exit(0);
+        } catch(NoClassDefFoundError e) {
+            System.err.println(String.format("Unable to load class \"%s\".", e.getMessage()));
+            System.exit(1);
+        }
+    }
+}

--- a/scripts/integration-test-cli
+++ b/scripts/integration-test-cli
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ex
 
 # Builds the CLI and daemon and runs a small integration test
 
@@ -21,8 +21,8 @@ ROOT_DIR="$(cd "$(dirname "$SCRIPT_NAME")" && cd .. && pwd)"
 cd "$ROOT_DIR"
 
 # Build projects
-(cd landlord && cargo build --release)
-(cd landlordd && sbt daemon/stage)
+#(cd landlord && cargo build --release)
+#(cd landlordd && sbt daemon/stage)
 
 # TODO remove the line below once alpakka #882, landlord #27, landlord #28 merged
 exit 0
@@ -30,7 +30,10 @@ exit 0
 # Start landlordd
 rm -rf "$DIR"
 mkdir -p "$DIR"
-landlordd/daemon/target/universal/stage/bin/landlordd --bind-dir-path "$DIR" --prevent-shutdown-hooks &
+landlordd/daemon/target/universal/stage/bin/landlordd \
+    --bind-dir-path "$DIR" \
+    --prevent-shutdown-hooks \
+    --class-profiles one=landlordd/test-deps/one/target/scala-2.12/classes,two=landlordd/test-deps/two/target/scala-2.12/classes &
 LANDLORDD_PID="$!"
 
 while ! [ -e "$DIR/landlordd.sock" ]; do
@@ -41,10 +44,19 @@ done
 OUTPUT=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -socket "$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
 EXPECTED='hello world
 Testing'
+[ "$OUTPUT" = "$EXPECTED" ]
+
+# Run a program that tests profile #1
+OUTPUT=$(./landlord/target/release/landlord -Dlandlord.class-profile=one -socket "$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Profile)
+EXPECTED='one'
+[ "$OUTPUT" = "$EXPECTED" ]
+
+# Run a program that tests profile #1
+OUTPUT=$(./landlord/target/release/landlord -Dlandlord.class-profile=two -socket "$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Profile)
+EXPECTED='two'
+[ "$OUTPUT" = "$EXPECTED" ]
 
 # Shutdown landlordd
 kill "$LANDLORDD_PID"
 wait
 
-# Test that we got what we expected
-[ "$OUTPUT" = "$EXPECTED" ]


### PR DESCRIPTION
Fixes #24 (and then some...)

This adds support for what I'm calling class profiles, which allow you to declare a number of named class loaders that a given application's class loader can descend from. Looking forward to discussing the design at the standup :wink:

An application declares a profile by name using the `-Dlandlord.class-profile=<name>`

Class profiles are registered with landlord via its arguments. For instance, the following shows starting landlord and the output of a program that varies depending upon the selected profile.

#### start landlordd with two profiles, `one` and `two`
```bash
landlordd/daemon/target/universal/stage/bin/landlordd  --class-profiles one=landlordd/test-deps/one/target/scala-2.12/classes,two=landlordd/test-deps/two/target/scala-2.12/classes
```

#### run app with profile `one`

```bash
landlord/target/release/landlord -Dlandlord.class-profile=one -cp landlordd/test/target/scala-2.12/classes example.Profile 
```
```
one
```

#### run app with profile `two`

```bash
landlord/target/release/landlord -Dlandlord.class-profile=two -cp landlordd/test/target/scala-2.12/classes example.Profile 
```
```
two
```

#### run app with invalid profile `asdf`

```bash
landlord/target/release/landlord -Dlandlord.class-profile=asdf -cp landlordd/test/target/scala-2.12/classes example.Profile
```
```
Class profile does not exist: asdf
```

#### run app without a profile

```bash
landlord/target/release/landlord -cp landlordd/test/target/scala-2.12/classes example.Profile 
```
```
built-in
```

You could imagine having e.g. `akka25`, `akka26` profiles, and so, without having to run multiple `landlordd` instances.