### PR TITLE
Client Docker image now FROM scratch, resulting in ~50% savings

### DIFF
--- a/landlord/Dockerfile
+++ b/landlord/Dockerfile
@@ -1,9 +1,5 @@
-FROM alpine:3.7
-WORKDIR /opt/docker
-RUN apk add --no-cache shadow
+FROM scratch
 COPY target/x86_64-unknown-linux-musl/release/landlord /usr/local/bin/
-RUN \
-  mkdir -p /var/run/landlord && \
-  chown daemon /var/run/landlord && \
-  usermod -d /var/run/landlord daemon
-USER daemon
+COPY --chown=2 empty /var/run/landlord
+ENTRYPOINT ["usr/local/bin/landlord"]
+USER 2

--- a/landlord/empty/.keep
+++ b/landlord/empty/.keep
@@ -1,0 +1,1 @@
+This directory exists so that we can initialize and chown /var/run/landlord despite building FROM scratch. This allows us to build the smallest Docker image possible, since the client itself is completely statically linked.

--- a/landlordd/Dockerfile
+++ b/landlordd/Dockerfile
@@ -1,4 +1,3 @@
 FROM landlord/landlord
-USER daemon
 COPY test/target/scala-2.12/classes /classes
-ENTRYPOINT ["/usr/local/bin/landlord", "-cp", "/classes", "-Dgreeting=Welcome", "example.Hello", "ArgOne", "ArgTwo"]
+CMD ["-cp", "/classes", "-Dgreeting=Welcome", "example.Hello", "ArgOne", "ArgTwo"]


### PR DESCRIPTION
This brings the client's image size down from 12.7MB to 6.55MB.

If we add TLS support in the future, this means a CA would have to be mounted from the host into the container, as there aren't any CAs in the image (since we're `FROM scratch`, all that exists is the static binary)