### PR TITLE
Improve Docker configuration.

### DIFF
--- a/landlord/Dockerfile
+++ b/landlord/Dockerfile
@@ -1,5 +1,5 @@
 FROM scratch
-COPY --chown=2 docker/ /
-COPY --chown=root target/x86_64-unknown-linux-musl/release/landlord /usr/local/bin/
+COPY --chown=2:2 docker/ /
+COPY --chown=daemon:daemon target/x86_64-unknown-linux-musl/release/landlord /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/landlord"]
 USER daemon

--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -52,13 +52,23 @@ lazy val daemon = project
     packageName in Docker := "landlordd",
     dockerUsername := Some("landlord"),
     dockerCommands := dockerCommands.value.flatMap {
+      case cmd @ Cmd("ADD", _) => Seq(
+        cmd,
+        Cmd(
+          "RUN",
+          s"""|chmod -R g+x /opt/docker/bin && \\
+              |chmod -R g+w /opt/docker
+           """.stripMargin)
+
+      )
       case cmd @ Cmd("WORKDIR", _) => Seq(
         cmd,
         Cmd(
           "RUN",
           s"""|apk add --no-cache shadow && \\
               |mkdir -p /var/run/landlord && \\
-              |chown ${daemonUser.value} /var/run/landlord && \\
+              |chown ${daemonUser.value}:${daemonGroup.value} /var/run/landlord && \\
+              |chmod 770 /var/run/landlord && \\
               |usermod -d /var/run/landlord ${daemonUser.value}
               |""".stripMargin)
       )


### PR DESCRIPTION
This allows members of the daemon group to execute relevant programs and read and write to relevant files.

By doing this, downstream images can specify their own UID and GID and simply ensure that the specified UID is a member of `daemon` (GID=2).

For instance, a user may wish to specify UID equal to a desktop session's UID so that files created in the container remain writable by the host.