### PR TITLE
Version extract was wrong when releasing

### DIFF
--- a/scripts/release-dockerhub
+++ b/scripts/release-dockerhub
@@ -10,7 +10,7 @@ if [ "$DOCKER_USERNAME" = "" ] || [ "$DOCKER_PASSWORD" = "" ]; then
   exit 3
 fi
 
-version=$(git name-rev --name-only HEAD | sed 's/^tags\/v//')
+version=$(git name-rev --name-only HEAD | sed -E 's/^tags\/v(.*)\^0/\1/')
 
 # Normalize dirs
 SCRIPT_NAME="${BASH_SOURCE[0]}"


### PR DESCRIPTION
Given a string of `tags/v0.1.3^0` then the script would complain that `^` is an invalid character for a version... fair enough too.

This commit strips off the tailing ^0. ^0 should always be the case as the script is invoked on a tag change - which should thus always be 0 commits offset from the tag - anything else means that it has probably been published before.