### PR TITLE
Synchronize shutdown hooks

### DIFF
--- a/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
+++ b/landlordd/daemon/src/main/scala/com/github/huntc/landlord/JvmExecutor.scala
@@ -152,7 +152,7 @@ object JvmExecutor {
               .filter(t => memberOfThreadGroup(t.getThreadGroup, group))
               .toSet
           } else {
-            throw new IllegalStateException("Could find the java.lang.ApplicationShutdownHooks.fields")
+            throw new IllegalStateException("Could not find the java.lang.ApplicationShutdownHooks.fields")
           }
         } catch {
           case _: NoSuchFieldException | _: ClassCastException | _: IllegalAccessException | _: IllegalArgumentException | _: ExceptionInInitializerError =>


### PR DESCRIPTION
This PR avoids concurrent execution errors when gathering the list of shutdown hooks.

Fixes #73 