### PR TITLE
Ensure that client handles signals when waiting for contact with landlordd

### DIFF
--- a/landlord/src/args.rs
+++ b/landlord/src/args.rs
@@ -200,10 +200,7 @@ fn test_parse_java_opts() {
         parse_java_opts("hello\\\\ trailing back slash"),
         vec!["hello\\", "trailing", "back", "slash"]
     );
-    assert_eq!(
-        parse_java_opts("  hello   world  "),
-        vec!["hello", "world"]
-    );
+    assert_eq!(parse_java_opts("  hello   world  "), vec!["hello", "world"]);
 }
 
 #[test]


### PR DESCRIPTION
Fixes https://github.com/landlord/landlord/issues/77

Test:

```bash
cargo build --target=x86_64-unknown-linux-musl --release
docker build --no-cache -t testing-landlord .
docker run -t -i testing-landlord -wait Test
```

Upon pressing `CTRL-C`, the client now receives the signal and exits.