### PR TITLE
Properly handle signals and zombie reaping

### DIFF
--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -65,7 +65,7 @@ lazy val daemon = project
         cmd,
         Cmd(
           "RUN",
-          s"""|apk add --no-cache shadow && \\
+          s"""|apk add --no-cache dumb-init shadow && \\
               |mkdir -p /var/run/landlord && \\
               |chown ${daemonUser.value}:${daemonGroup.value} /var/run/landlord && \\
               |chmod 770 /var/run/landlord && \\
@@ -75,6 +75,7 @@ lazy val daemon = project
       case cmd => Seq(cmd)
     },
     dockerBaseImage := "openjdk:8-jre-alpine",
+    dockerEntrypoint := Seq("/usr/bin/dumb-init", "--single-child", "--") ++ dockerEntrypoint.value,
     bashScriptExtraDefines ++= Seq(
       // Configuration for when running in a container
       """addJava "-XX:+UnlockExperimentalVMOptions"""",


### PR DESCRIPTION
Modifies Docker configuration for landlordd to use `dumb-init` which will reap zombies and ensure signals are handled properly.

Fixes https://github.com/landlord/landlord/issues/78

This [README.md](https://github.com/Yelp/dumb-init/blob/master/README.md) does a good job of explaining why this is necessary.

Here's the process hierarchy with this in place:

```bash
~/work/farmco/landlord/landlord#dumb-init $ docker exec -t -i b262349dcc09 /bin/sh
/opt/docker $ ps
PID   USER     TIME   COMMAND
    1 daemon     0:00 /usr/bin/dumb-init --single-child -- /opt/docker/bin/land
    8 daemon     0:02 java -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemor
   57 daemon     0:00 /bin/sh
   64 daemon     0:00 ps
/opt/docker $ -> 0

```