### PR TITLE
Improve the shutdown logic when multiple applications are running

### DIFF
--- a/landlordd/daemon/src/main/resources/application.conf
+++ b/landlordd/daemon/src/main/resources/application.conf
@@ -1,4 +1,12 @@
 akka {
+  coordinated-shutdown {
+    phases {
+      before-actor-system-terminate {
+        timeout = 8s
+      }
+    }
+  }
+
   log-dead-letters                 = off
   log-dead-letters-during-shutdown = off
   loggers                          = [akka.event.slf4j.Slf4jLogger]


### PR DESCRIPTION
* Shutdown timeout set to 8 seconds to stay under 10 second Docker limit
* Fix spurious logging when unable to access shutdown hooks due to shutdown
* Fix reaper logic so that it properly replies when multiple applications are running
* Ignore InterruptedException thrown during JVM shutdown as they are expected

Fixes #22 

Will discuss further during today's meeting.