### PR TITLE
Uses Alpine as the base

### DIFF
--- a/landlord/Dockerfile
+++ b/landlord/Dockerfile
@@ -1,4 +1,4 @@
-FROM scratch
+FROM alpine:3.7
 COPY --chown=2:2 docker/ /
 COPY --chown=daemon:daemon target/x86_64-unknown-linux-musl/release/landlord /usr/local/bin/
 ENTRYPOINT ["/usr/local/bin/landlord"]


### PR DESCRIPTION
Building images from scratch causes problems on Cisco IOx.

Fixes #83 