### PR TITLE
Ensure that the Java KeyStore is writable by the daemon group

### DIFF
--- a/landlordd/build.sbt
+++ b/landlordd/build.sbt
@@ -57,7 +57,9 @@ lazy val daemon = project
         Cmd(
           "RUN",
           s"""|chmod -R g+x /opt/docker/bin && \\
-              |chmod -R g+w /opt/docker
+              |chmod -R g+w /opt/docker && \\
+              |chown :${daemonGroup.value} /etc/ssl/certs/java/cacerts && \\
+              |chmod -R g+w /etc/ssl/certs/java/cacerts
            """.stripMargin)
 
       )


### PR DESCRIPTION
Changes the group of `/etc/ssl/certs/java/cacerts` to the `daemonGroup.value` group (`daemon` by default), and makes it writable.

This is required for our Sandbox environment to be able to modify the keystore and add certificates. On IOx, I presume it's running as root which is why this issue wasn't noticed before.