### PR TITLE
Enhance -wait, allowing arbitrary addresses to be specified.

### DIFF
--- a/landlord/src/proto.rs
+++ b/landlord/src/proto.rs
@@ -203,8 +203,7 @@ pub fn class_path_with_names<S: AsRef<str>>(class_path: &[S]) -> Vec<(String, St
             } else {
                 (e.to_string(), i.to_string(), i.to_string())
             }
-        })
-        .collect()
+        }).collect()
 }
 
 /// given a reader, reads a landlord payload, i.e. a 4-byte encoded (big endian) size followed

--- a/scripts/integration-test-cli
+++ b/scripts/integration-test-cli
@@ -33,7 +33,7 @@ landlordd/daemon/target/universal/stage/bin/landlordd --host "unix://$DIR/landlo
 LANDLORDD_PID="$!"
 
 # Test landlord -wait parameter by starting before landlordd is given time to start
-OUTPUT1=$(echo Testing | ./landlord/target/release/landlord -wait -Dgreeting='hello world' -H "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
+OUTPUT1=$(echo Testing | ./landlord/target/release/landlord -ready landlordd -wait -Dgreeting='hello world' -H "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)
 
 # Run a program that uses stdin and properties
 OUTPUT2=$(echo Testing | ./landlord/target/release/landlord -Dgreeting='hello world' -H "unix://$DIR/landlordd.sock" -cp landlordd/test/target/scala-2.12/classes example.Hello)


### PR DESCRIPTION
Enhance `-wait`, allowing arbitrary addresses to be specified. Initially, the scheme `tcp` is supported.

When `-wait landlordd` is specified, the client will wait until landlordd is online before attempting to connect.

When `-wait tcp://<host>:<port>` is specified, the client will wait until it can connect to the specified address.

Multiple combinations of this flag can be specified; they will be tried in order.

A previous command of `landlord -wait` must now be specified as `landlord -wait landlordd`.

@huntc This helps us in our sandbox scenario and may be useful for other purposes as well, but be sure to check chat for the ideas on the bigger picture.